### PR TITLE
OBS flatpak version installer script

### DIFF
--- a/install-scripts/obs-flatpak-version-install.sh
+++ b/install-scripts/obs-flatpak-version-install.sh
@@ -1,0 +1,10 @@
+# This install script is specficialyl for the Flatpak install version of OBS Studio
+# Main install location
+#~/.var/app/com.obsproject.Studio/config/obs-studio
+#!/bin/sh
+
+echo "Installing Teleport into ~/.var/app/com.obsproject.Studio/config/obs-studio/plugins/obs-teleport/bin/64bit/obs-teleport.so"
+rm -rf ~/.var/app/com.obsproject.Studio/config/obs-studio/plugins/obs-teleport
+mkdir -p ~/.var/app/com.obsproject.Studio/config/obs-studio/plugins/obs-teleport/bin/64bit
+cp $(dirname $0)/obs-teleport.so ~/.var/app/com.obsproject.Studio/config/obs-studio/plugins/obs-teleport/bin/64bit/obs-teleport.so
+echo "Successfully installed OBS Teleport Flatpak installation version"


### PR DESCRIPTION
What this does:

This install script simply replaces the directory of the OBS install folder to that being used in flatpak OBS as flatpak OBS is different to the install location of apt-get install.

How should this be used:

This script should be packaged inside of the linux-x86_64 folder, alongside obs-teleport.so.

<img width="398" height="189" alt="image" src="https://github.com/user-attachments/assets/51fa0a07-3258-42d8-b8c1-f9ab4404e508" />

What if not packaged?

Simply drag and drop the script and the .so file into the same directory.

Why?

Because flatpak OBS is the new recommended way to download OBS even outlined int he OBS website and is also the main method in the Software Manager on Linux Mint.